### PR TITLE
Remove redundant checks on cloneclean service

### DIFF
--- a/ymls/cleaner.yml
+++ b/ymls/cleaner.yml
@@ -38,8 +38,6 @@
 
 - name: 'Daemon-Reload for cloneclean'
   systemd: state=stopped name=cloneclean daemon_reload=yes enabled=no
-  when: cxp.stat.exists
 
 - name: 'Start Service for CloneClean'
   systemd: state=started name=cloneclean enabled=yes
-  when: cxp.stat.exists


### PR DESCRIPTION
This fixes issues with cloneclean not getting started if people are upgrading from previous versions of PTS on the old uploader.
Every run reinstalls the cloneclean.service and it should always be there. Worse case, it fails and throws an error to start up the service.